### PR TITLE
Add GitHub Action for client template generation

### DIFF
--- a/.github/workflows/generate-template.yml
+++ b/.github/workflows/generate-template.yml
@@ -1,0 +1,63 @@
+name: Generate Client Template
+
+on:
+  workflow_dispatch:
+    inputs:
+      config_filename:
+        description: 'Filename of the client config (e.g., clientA.json). Expected in krs-main/client_configs/.'
+        required: true
+        type: string
+      branch_name:
+        description: 'Name for the new branch (e.g., client/clientA).'
+        required: true
+        type: string
+
+jobs:
+  generate_and_commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Define Output Directory
+        id: paths
+        run: echo "OUTPUT_DIR=client_template_output" >> $GITHUB_ENV
+
+      - name: Run Template Generation Script
+        run: |
+          python krs-main/generate_client_template.py krs-main/client_configs/${{ github.event.inputs.config_filename }} ${{ env.OUTPUT_DIR }}
+        env:
+          PYTHONPATH: . # Ensures krs-main can be imported if needed by scripts
+
+      - name: Commit and Push to New Branch
+        run: |
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+
+          # Create new branch from the current HEAD
+          git checkout -b ${{ github.event.inputs.branch_name }}
+
+          # Copy generated files from output directory to the repo root for the new branch
+          # This assumes the output_dir contains the complete desired structure (borders.php, inline.css etc. at its root)
+          # Use rsync to overwrite existing files from the base template with the generated ones.
+          # The dot at the end of rsync copies contents of OUTPUT_DIR into the current directory (branch root).
+          rsync -av --delete ${{ env.OUTPUT_DIR }}/ .
+
+          # If OUTPUT_DIR itself should not be committed, add it to .gitignore if not already present
+          # Or remove it after copying if it was created within the tracked repo structure
+          # For now, assuming it's a temporary staging for files to be moved to root.
+          # rm -rf ${{ env.OUTPUT_DIR }} # Optional: clean up the temp output dir if it's in the repo structure
+
+          git add .
+          # Check if there are changes to commit to avoid error with empty commit
+          if ! git diff --staged --quiet; then
+            git commit -m "Generate client template from ${{ github.event.inputs.config_filename }} for ${{ github.event.inputs.branch_name }}"
+            git push -u origin ${{ github.event.inputs.branch_name }}
+          else
+            echo "No changes to commit. Template may be identical or script failed silently."
+          fi

--- a/krs-main/README.md
+++ b/krs-main/README.md
@@ -127,3 +127,96 @@ Review and update configurations for external services.
     *   `[[service_area_google_map]]` (L364 in `borders.php`). This will require configuration with the new company's service area data and potentially API keys.
 
 By addressing these areas, the template can be successfully adapted for a new company's website.
+
+## Automated Client Template Generation
+
+This section describes how to use the provided Python script and JSON configuration to automate much of the template customization process.
+
+### 1. Overview
+
+The automation relies on two key components:
+*   `krs-main/config.json_template`: A template file for client-specific configurations.
+*   `krs-main/generate_client_template.py`: A Python script that processes the configuration and applies it to a copy of the template.
+
+### 2. `config.json_template` Usage
+
+1.  **Copy the Template:**
+    *   Locate the `krs-main/config.json_template` file.
+    *   Copy this file to a new location (e.g., a client-specific project directory or a temporary working folder).
+    *   Rename the copied file to `config.json`.
+
+2.  **Edit `config.json`:**
+    *   Open your newly created `config.json` file in a text editor.
+    *   Carefully review and update the placeholder values with the specific client's information. This includes:
+        *   Company details (`companyInfo`): Name, phone, address, service areas, etc.
+        *   Website settings (`websiteSettings`): Metadata, URLs for new logos, favicon, and other brand-specific assets.
+        *   Theme preferences (`theme`): Desired primary, secondary, text, and background colors; primary and secondary font family declarations.
+        *   Homepage content (`homepageContent`): URLs for specific homepage images (e.g., main background, owner photo).
+        *   Service information (`serviceInfo`): Links to service pages, URLs for service-specific header images or icons.
+        *   Navigation (`navigation.socialMediaLinks`): URLs for the client's social media profiles.
+        *   Integrations (`integrations`): New Google Fonts URL, Adobe Fonts Kit ID, Google Maps API key if applicable.
+    *   Refer to the structure and comments within `config.json_template` for guidance on what each field represents.
+
+### 3. `generate_client_template.py` Usage
+
+1.  **The Script:**
+    *   The script `krs-main/generate_client_template.py` is responsible for creating a new client-specific template folder and applying the customizations defined in your `config.json`.
+
+2.  **Command-Line Execution:**
+    *   Open your terminal or command prompt.
+    *   Navigate to the directory that *contains* the `krs-main` folder (i.e., the parent directory of `krs-main`).
+    *   Run the script using the following command structure:
+
+    ```bash
+    python krs-main/generate_client_template.py path/to/your/client_config.json new_client_template_folder_name
+    ```
+
+    *   **`path/to/your/client_config.json`**: This is the full or relative path to the `config.json` file you prepared in the previous step.
+    *   **`new_client_template_folder_name`**: This is the name for the new directory that will be created to house the customized template files (e.g., `krs_client_abc_site`). This folder will be created at the same level as the `krs-main` directory.
+
+3.  **Script Actions:**
+    *   The script will first create the `new_client_template_folder_name` directory.
+    *   It will then copy all files and subdirectories from the `krs-main` template into this new folder, excluding `generate_client_template.py` itself and `config.json_template`.
+    *   Next, it will read your specified `client_config.json`.
+    *   Finally, it will process `borders.php`, `inline.css`, and `template.css` within the new folder, replacing placeholders and hardcoded values (like colors, fonts, and specific URLs) with the settings from your configuration file.
+
+### 4. Output
+
+Upon successful execution, you will have a new folder (e.g., `krs_client_abc_site`) containing a version of the web template tailored with the client's specific information, branding, and asset links as defined in your `config.json`.
+
+### 5. Important Notes
+
+*   **Python Version:** This script is intended for use with Python 3.
+*   **Server-Side Placeholders:** Placeholders that are processed by server-side languages/CMS (e.g., `[[content]]`, `[[top_nav]]`, `[[single_silo_nav]]`, `[[social_footer]]`, `[[custom_core_v3_5]]`, `[[custom_core_v3_js]]`) are generally *not* replaced with final content by this Python script. They will remain in the generated PHP files for the server-side rendering engine or CMS to handle. The script may replace some of these with HTML comments or basic structural links if defined in the config (e.g., custom CSS/JS links).
+*   **Review Output:** Always review the generated files to ensure all replacements have occurred as expected and to make any further manual adjustments if necessary.
+*   **Backup:** It's always a good practice to work with version control or have backups of your original template and configuration files.
+
+### Using the GitHub Action for Template Generation
+
+For a more integrated approach, you can use the GitHub Action to generate client templates.
+
+1.  **Accessing the Action:**
+    *   Navigate to the main page of the repository on GitHub.
+    *   Click on the "Actions" tab.
+    *   In the left sidebar, you will find a list of workflows. Click on "Generate Client Template".
+
+2.  **Manual Trigger:**
+    *   This workflow is designed for manual triggering via `workflow_dispatch`.
+    *   Above the list of workflow runs, you will see a "Run workflow" dropdown button. Click it.
+
+3.  **Input Parameters:**
+    *   You will be prompted to provide the following inputs:
+        *   **`config_filename`**: Enter the name of the client's JSON configuration file (e.g., `clientA.json`). This file **must be located in the `krs-main/client_configs/` directory** within the repository *before* running the action.
+        *   **`branch_name`**: Specify the desired name for the new branch that will be created to store the generated client template (e.g., `client/clientA`, `feature/clientA-template`).
+
+4.  **Running the Action:**
+    *   After filling in the input parameters, select the branch you want to run the workflow from (usually your main development branch, e.g., `main` or `master`).
+    *   Click the "Run workflow" button.
+
+5.  **Outcome:**
+    *   The GitHub Action will execute the `krs-main/generate_client_template.py` script using the configuration you specified.
+    *   Upon successful completion, a new branch (with the name you provided for `branch_name`) will be automatically created in the repository. This branch will contain the full website template, customized with the client's information and branding from their configuration file. The customized files will be at the root of this new branch.
+
+6.  **Prerequisites:**
+    *   Ensure the client's JSON configuration file (e.g., `clientA.json`) has been created, populated, and pushed to the `krs-main/client_configs/` directory in the repository *before* attempting to run the GitHub Action.
+    *   The `generate_client_template.py` script must be up-to-date in the branch from which you run the workflow.

--- a/krs-main/client_configs/example_client.json
+++ b/krs-main/client_configs/example_client.json
@@ -1,0 +1,102 @@
+{
+  "companyInfo": {
+    "name": "Client Company Name",
+    "phone": "1-800-555-1212",
+    "email": "contact@example.com",
+    "address": "123 Main Street, Anytown, ST 12345",
+    "licenseNumber": "CL-1234567890",
+    "serviceTerritory": "Greater Anytown Region",
+    "majorCities": [
+      "Anytown",
+      "Springfield",
+      "Shelbyville"
+    ],
+    "state": "YourState"
+  },
+  "websiteSettings": {
+    "title": "Default Website Title - [Company Name]",
+    "metaDescription": "Default meta description for [Company Name].",
+    "metaKeywords": "roofing, repair, replacement, [city1], [city2]",
+    "faviconUrl": "/assets/images/custom/favicon.ico",
+    "logoUrl": "/assets/images/custom/logo_main.png",
+    "stickyLogoUrl": "/assets/images/custom/logo_sticky.png",
+    "noNailPledgeBadgeUrl": "/assets/images/custom/no_nail_pledge.png",
+    "contractorNationLogoUrl": "/assets/images/custom/cn_logo.png",
+    "klausBrandSvgUrl": "/assets/images/custom/klaus_brand.svg",
+    "klausHausSvgUrl": "/assets/images/custom/klaus_haus.svg",
+    "customCssUrl": "assets/css/custom.css",
+    "customJsUrl": "assets/js/custom.js"
+  },
+  "theme": {
+    "primaryColor": "#FF0000",
+    "secondaryColor": "#00FF00",
+    "accentColorYellow": "#FFFF00",
+    "accentColorLightGray": "#DDDDDD",
+    "accentColorBlue": "#0000FF",
+    "accentColorBrightRed": "#EE0000",
+    "textColorDark": "#333333",
+    "textColorLight": "#FFFFFF",
+    "backgroundColorLight": "#F8F8F8",
+    "backgroundColorDark": "#222222",
+    "fontPrimary": "'Open Sans', sans-serif",
+    "fontSecondary": "'Roboto', sans-serif",
+    "fontCustom1": "'Brother-1816', sans-serif"
+  },
+  "homepageContent": {
+    "mainMessageHeadline": "Quality Services from [Company Name]!",
+    "mainMessageOffer": "Get a Free Estimate Today!",
+    "mainMessageCtaLink": "/free-estimate.html",
+    "mainMessageBackgroundUrl": "/assets/images/custom/main_message_bg.jpg",
+    "ownerPhotoUrl": "/assets/images/custom/owner_photo.jpg",
+    "marketingImageUrl": "/assets/images/custom/marketing_image_homepage.png",
+    "warrantyBannerDesktopUrl": "/assets/images/custom/warranty_banner_desktop.png",
+    "warrantyBannerMobileUrl": "/assets/images/custom/warranty_banner_mobile.png"
+  },
+  "serviceInfo": {
+    "defaultSiloHeaderBackground": "/assets/images/stock_generic/silo_header_default.jpg",
+    "servicePageLinks": [
+      {
+        "name": "Roof Repair",
+        "url": "/roof-repair.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/roof_repair_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_repair.png"
+      },
+      {
+        "name": "Roof Replacement",
+        "url": "/roof-replacement.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/roof_replacement_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_replacement.png"
+      },
+      {
+        "name": "Gutter Installation",
+        "url": "/gutter-installation.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/gutter_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_gutters.png"
+      },
+      {
+        "name": "Siding",
+        "url": "/siding.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/siding_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_siding.png"
+      }
+    ],
+    "whyChooseUsBackgroundUrl": "/assets/images/custom/why_choose_us_bg.jpg",
+    "numberedListIconsPath": "/assets/images/icons/numbered_list/",
+    "playButtonIconUrl": "/assets/images/icons/play_button.png"
+  },
+  "navigation": {
+    "socialMediaLinks": {
+      "facebook": "https://facebook.com/yourcompany",
+      "twitter": "https://twitter.com/yourcompany",
+      "linkedin": "https://linkedin.com/company/yourcompany",
+      "youtube": "https://youtube.com/yourcompany",
+      "instagram": "https://instagram.com/yourcompany"
+    }
+  },
+  "integrations": {
+    "googleFontsUrl": "https://fonts.googleapis.com/css?family=Open+Sans:400,700&family=Roboto:400,700&display=swap",
+    "adobeFontsKitId": "NEW_ADOBE_FONT_KIT_ID",
+    "googleMapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE",
+    "stickySidebarJsUrl": "https://a80427d48f9b9f165d8d-c913073b3759fb31d6b728a919676eab.ssl.cf1.rackcdn.com/v3/js/sticky-sidebar.js"
+  }
+}

--- a/krs-main/config.json_template
+++ b/krs-main/config.json_template
@@ -1,0 +1,102 @@
+{
+  "companyInfo": {
+    "name": "Client Company Name",
+    "phone": "1-800-555-1212",
+    "email": "contact@example.com",
+    "address": "123 Main Street, Anytown, ST 12345",
+    "licenseNumber": "CL-1234567890",
+    "serviceTerritory": "Greater Anytown Region",
+    "majorCities": [
+      "Anytown",
+      "Springfield",
+      "Shelbyville"
+    ],
+    "state": "YourState"
+  },
+  "websiteSettings": {
+    "title": "Default Website Title - [Company Name]",
+    "metaDescription": "Default meta description for [Company Name].",
+    "metaKeywords": "roofing, repair, replacement, [city1], [city2]",
+    "faviconUrl": "/assets/images/custom/favicon.ico",
+    "logoUrl": "/assets/images/custom/logo_main.png",
+    "stickyLogoUrl": "/assets/images/custom/logo_sticky.png",
+    "noNailPledgeBadgeUrl": "/assets/images/custom/no_nail_pledge.png",
+    "contractorNationLogoUrl": "/assets/images/custom/cn_logo.png",
+    "klausBrandSvgUrl": "/assets/images/custom/klaus_brand.svg",
+    "klausHausSvgUrl": "/assets/images/custom/klaus_haus.svg",
+    "customCssUrl": "assets/css/custom.css",
+    "customJsUrl": "assets/js/custom.js"
+  },
+  "theme": {
+    "primaryColor": "#FF0000",
+    "secondaryColor": "#00FF00",
+    "accentColorYellow": "#FFFF00",
+    "accentColorLightGray": "#DDDDDD",
+    "accentColorBlue": "#0000FF",
+    "accentColorBrightRed": "#EE0000",
+    "textColorDark": "#333333",
+    "textColorLight": "#FFFFFF",
+    "backgroundColorLight": "#F8F8F8",
+    "backgroundColorDark": "#222222",
+    "fontPrimary": "'Open Sans', sans-serif",
+    "fontSecondary": "'Roboto', sans-serif",
+    "fontCustom1": "'Brother-1816', sans-serif"
+  },
+  "homepageContent": {
+    "mainMessageHeadline": "Quality Services from [Company Name]!",
+    "mainMessageOffer": "Get a Free Estimate Today!",
+    "mainMessageCtaLink": "/free-estimate.html",
+    "mainMessageBackgroundUrl": "/assets/images/custom/main_message_bg.jpg",
+    "ownerPhotoUrl": "/assets/images/custom/owner_photo.jpg",
+    "marketingImageUrl": "/assets/images/custom/marketing_image_homepage.png",
+    "warrantyBannerDesktopUrl": "/assets/images/custom/warranty_banner_desktop.png",
+    "warrantyBannerMobileUrl": "/assets/images/custom/warranty_banner_mobile.png"
+  },
+  "serviceInfo": {
+    "defaultSiloHeaderBackground": "/assets/images/stock_generic/silo_header_default.jpg",
+    "servicePageLinks": [
+      {
+        "name": "Roof Repair",
+        "url": "/roof-repair.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/roof_repair_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_repair.png"
+      },
+      {
+        "name": "Roof Replacement",
+        "url": "/roof-replacement.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/roof_replacement_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_replacement.png"
+      },
+      {
+        "name": "Gutter Installation",
+        "url": "/gutter-installation.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/gutter_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_gutters.png"
+      },
+      {
+        "name": "Siding",
+        "url": "/siding.html",
+        "siloHeaderImageUrl": "/assets/images/custom_services/siding_header.jpg",
+        "serviceBoxImageUrl": "/assets/images/custom_services/service_box_siding.png"
+      }
+    ],
+    "whyChooseUsBackgroundUrl": "/assets/images/custom/why_choose_us_bg.jpg",
+    "numberedListIconsPath": "/assets/images/icons/numbered_list/",
+    "playButtonIconUrl": "/assets/images/icons/play_button.png"
+  },
+  "navigation": {
+    "socialMediaLinks": {
+      "facebook": "https://facebook.com/yourcompany",
+      "twitter": "https://twitter.com/yourcompany",
+      "linkedin": "https://linkedin.com/company/yourcompany",
+      "youtube": "https://youtube.com/yourcompany",
+      "instagram": "https://instagram.com/yourcompany"
+    }
+  },
+  "integrations": {
+    "googleFontsUrl": "https://fonts.googleapis.com/css?family=Open+Sans:400,700&family=Roboto:400,700&display=swap",
+    "adobeFontsKitId": "NEW_ADOBE_FONT_KIT_ID",
+    "googleMapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE",
+    "stickySidebarJsUrl": "https://a80427d48f9b9f165d8d-c913073b3759fb31d6b728a919676eab.ssl.cf1.rackcdn.com/v3/js/sticky-sidebar.js"
+  }
+}

--- a/krs-main/generate_client_template.py
+++ b/krs-main/generate_client_template.py
@@ -1,0 +1,338 @@
+import argparse
+import json
+import os
+import shutil
+import re
+
+# --- Configuration for Placeholders and CSS Selectors ---
+
+# CSS Color Replacements: (Original_Color_Regex_Pattern, Config_Theme_Key_For_New_Color)
+CSS_COLOR_REPLACEMENTS = [
+    (r"#d8340c", "primaryColor"),        # KRS Red
+    (r"#FCD066", "accentColorYellow"),   # KRS Yellow
+    (r"#1E1E1E", "textColorDark"),       # Dark Gray / Black text
+    (r"#000000", "backgroundColorDark"), # Pure Black background (use with context awareness)
+    (r"#222222", "textColorDark"),
+    (r"#313131", "textColorDark"),
+    (r"#353535", "textColorDark"),
+    (r"#555555", "textColorDark"),       # Medium Gray text
+    (r"#666666", "textColorDark"),       # Medium Gray text
+    (r"#bbbbbb", "accentColorLightGray"), # Light Gray for borders/backgrounds
+    (r"#ededed", "backgroundColorLight"),# Very Light Gray background
+    (r"#f1f1f1", "backgroundColorLight"), # Very Light Gray background
+    (r"#274287", "accentColorBlue"),     # A specific blue found
+    (r"#ed242c", "accentColorBrightRed") # Financing Red
+]
+
+# Font Family Replacements: (Original_Font_Regex_Pattern, Config_Theme_Key_For_New_Font)
+CSS_FONT_REPLACEMENTS = [
+    (r"['\"]Montserrat['\"],\s*sans-serif", "fontPrimary"),
+    (r"['\"]Montserrat['\"],\s*serif", "fontPrimary"), # Catch serif version too
+    (r"['\"]brother-1816['\"]", "fontCustom1") # Example for a custom font
+]
+
+# Specific URL replacements in CSS: (Original_URL_Regex_Pattern, Config_Key_Path_For_New_URL)
+# Note: Config_Key_Path uses dot notation for nesting, e.g., "section.subsection.key"
+CSS_URL_REPLACEMENTS = {
+    "inline.css": [
+        (r"url\(['\"]https://cdn.treehouseinternetgroup.com/cms_images/4148/DIMS_FINAL2_Black.png['\"]\)", "websiteSettings.stickyLogoUrl"),
+        (r"url\(/core/images/toolbox/red-royal/(\d+)\.png\)", "serviceInfo.numberedListIconsPath") # Path prefix for numbered icons
+    ],
+    "template.css": [
+        # Service Box Images - These might need more dynamic handling if service items change frequently.
+        # For now, examples for a few specific replacements.
+        (r"url\('https://cdn.treehouseinternetgroup.com/cdn-cgi/image/quality=75,\s*format=auto/cms_images/2900/RepairServicebutton.png'\)", "serviceInfo.servicePageLinks.0.serviceBoxImageUrl"), # Assumes first service in config
+        (r"url\('https://cdn.treehouseinternetgroup.com/cms_images/2882/roof-repair.jpg'\)", "serviceInfo.servicePageLinks.0.serviceBoxImageUrl"), # Can map multiple old URLs to the same new configured one
+        (r"url\('https://cdn.treehouseinternetgroup.com/cms_images/4148/disaster-restoration_service-img.png'\)", "serviceInfo.servicePageLinks.1.serviceBoxImageUrl"), # Assumes second service
+        (r"url\(https://cdn.treehouseinternetgroup.com/cms_images/2738/klaus-haus.svg\)", "websiteSettings.klausHausSvgUrl"),
+        (r"url\(\"/core/images/templates/des/play-btn.png\"\)", "serviceInfo.playButtonIconUrl")
+        # Example for a generic silo header if needed:
+        # (r"url\('/core/images/templates/spruce/headers/silo-roofing-2.jpg'\)", "serviceInfo.defaultSiloHeaderBackground")
+    ]
+}
+
+# Known PHP placeholders (literal strings)
+PHP_PLACEHOLDERS = {
+    "title": "[[title]]",
+    "description": "[[description]]",
+    "keywords": "[[keywords]]",
+    "custom_core_v3_5_css": "[[custom_core_v3_5]]",
+    "inline_css": "[[inline_css]]", # This is a special placeholder for inline CSS block, not for replacement by this script
+    "company_alt_text": "[company]",
+    "territory_header": "[territory]",
+    "major_cities_header": "[major cities 3]",
+    "phone_display": "[phone]",
+    "state_display": "[state]",
+    "top_nav": "[[top_nav]]", # CMS managed
+    "breadcrumbs": "[[breadcrumbs]]", # CMS managed
+    "content_main": "[[content]]", # CMS managed
+    "single_silo_nav": "[[single_silo_nav]]", # CMS managed
+    "city_scroll": "[[city_scroll:50]]", # CMS managed
+    "service_area_google_map": "[[service_area_google_map]]", # CMS managed
+    "social_footer": "[[social_footer]]", # CMS managed
+    "display_addresses": "[[display_addresses]]",
+    "license_number_comment": "[license number]", # Placeholder within a comment
+    "cn_logo_placeholder": "[[cn-logo]]",
+    "custom_core_v3_js": "[[custom_core_v3_js]]"
+}
+
+
+def get_config_value(config, key_path, default=None):
+    """Safely gets a value from a nested config dictionary using a dot-separated path."""
+    keys = key_path.split('.')
+    value = config
+    try:
+        for key in keys:
+            if isinstance(value, list):
+                idx = int(key)
+                if 0 <= idx < len(value):
+                    value = value[idx]
+                else:
+                    # print(f"Warning: Index {idx} out of bounds for key path '{key_path}'.")
+                    return default
+            elif isinstance(value, dict):
+                value = value[key]
+            else:
+                # print(f"Warning: Cannot access key '{key}' from non-dict/list type for key path '{key_path}'.")
+                return default
+        return value
+    except (KeyError, TypeError, IndexError, ValueError) : # Added ValueError for int conversion
+        # print(f"Warning: Key path '{key_path}' not found or invalid in config. Using default: {default}. Error: {e}")
+        return default
+
+def create_output_folder(output_folder_name):
+    """Creates the output folder relative to the current working directory."""
+    # Output path is relative to the current working directory
+    output_path = os.path.join(os.getcwd(), output_folder_name)
+
+    if os.path.exists(output_path):
+        print(f"Output folder '{output_path}' already exists. Removing it.")
+        try:
+            shutil.rmtree(output_path)
+        except OSError as e:
+            print(f"Error removing existing folder '{output_path}': {e}")
+            return None
+    try:
+        os.makedirs(output_path)
+        print(f"Created output folder: {output_path}")
+        return output_path
+    except OSError as e:
+        print(f"Error creating output folder '{output_path}': {e}")
+        return None
+
+def copy_template_files(script_dir, output_folder_path):
+    """Copies files from krs-main (script_dir) to the output folder, excluding specific files."""
+    source_dir = script_dir # This is the krs-main directory
+    excluded_files = ['generate_client_template.py', 'config.json_template', '.git']
+
+    try:
+        for item_name in os.listdir(source_dir):
+            if item_name in excluded_files or item_name.startswith('.'): # Also exclude other hidden files
+                continue
+
+            source_item_path = os.path.join(source_dir, item_name)
+            destination_item_path = os.path.join(output_folder_path, item_name)
+
+            if os.path.isdir(source_item_path):
+                shutil.copytree(source_item_path, destination_item_path, symlinks=False)
+            else:
+                shutil.copy2(source_item_path, destination_item_path)
+        print(f"Copied template files from '{source_dir}' to '{output_folder_path}'")
+    except Exception as e:
+        print(f"Error copying template files: {e}")
+        return False
+    return True
+
+def load_config(config_path):
+    """Loads the client's JSON configuration file."""
+    try:
+        # Ensure config_path is absolute or correctly relative to CWD
+        abs_config_path = os.path.abspath(config_path)
+        with open(abs_config_path, 'r', encoding='utf-8') as f:
+            config_data = json.load(f)
+        print(f"Loaded configuration from: {abs_config_path}")
+        return config_data
+    except FileNotFoundError:
+        print(f"Error: Configuration file not found at '{os.path.abspath(config_path)}'")
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON configuration file '{os.path.abspath(config_path)}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred while loading config '{os.path.abspath(config_path)}': {e}")
+    return None
+
+def process_borders_php(output_folder_path, config):
+    """Reads, processes, and writes changes to borders.php in the output folder."""
+    borders_file_path = os.path.join(output_folder_path, 'borders.php')
+
+    try:
+        with open(borders_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: '{borders_file_path}' not found in the output folder.")
+        return
+    except Exception as e:
+        print(f"Error reading '{borders_file_path}': {e}")
+        return
+
+    # Metadata and Head
+    content = content.replace(PHP_PLACEHOLDERS["title"], get_config_value(config, 'websiteSettings.title', 'Default Title'))
+    content = content.replace(PHP_PLACEHOLDERS["description"], get_config_value(config, 'websiteSettings.metaDescription', 'Default Description'))
+    content = content.replace(PHP_PLACEHOLDERS["keywords"], get_config_value(config, 'websiteSettings.metaKeywords', 'default, keywords'))
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/4148/favicon.ico', get_config_value(config, 'websiteSettings.faviconUrl', 'assets/favicon.ico'))
+
+    # Logo and Company Info
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/4148/DIMS-Roofing-Restoration.png', get_config_value(config, 'websiteSettings.logoUrl', 'assets/logo.png'))
+    content = content.replace(PHP_PLACEHOLDERS["company_alt_text"], get_config_value(config, 'companyInfo.name', 'Client Company'))
+    content = content.replace(PHP_PLACEHOLDERS["territory_header"], get_config_value(config, 'companyInfo.serviceTerritory', 'Service Area'))
+    major_cities = get_config_value(config, 'companyInfo.majorCities', [])
+    content = content.replace(PHP_PLACEHOLDERS["major_cities_header"], ', '.join(major_cities[:3]))
+
+    # Phone (used in multiple places, simple string replacement)
+    content = content.replace(PHP_PLACEHOLDERS["phone_display"], get_config_value(config, 'companyInfo.phone', 'N/A'))
+
+    content = content.replace(PHP_PLACEHOLDERS["state_display"], get_config_value(config, 'companyInfo.state', 'N/A'))
+    content = content.replace(PHP_PLACEHOLDERS["display_addresses"], get_config_value(config, 'companyInfo.address', 'N/A'))
+
+    # License Number (uncomment and replace)
+    license_placeholder_str = PHP_PLACEHOLDERS["license_number_comment"]
+    new_license_text = f"Contractor ID: {get_config_value(config, 'companyInfo.licenseNumber', 'N/A')}"
+    content = re.sub(r"<!-----p>\s*Contractor ID: " + re.escape(license_placeholder_str) + r"\s*</p------>", f"<p>{new_license_text}</p>", content)
+
+    # CN Logo
+    cn_logo_url = get_config_value(config, 'websiteSettings.contractorNationLogoUrl')
+    cn_logo_html = f'<img src="{cn_logo_url}" alt="Contractor Nation Affiliated">' if cn_logo_url else ''
+    content = content.replace(PHP_PLACEHOLDERS["cn_logo_placeholder"], cn_logo_html)
+
+    # Homepage specific images
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/4148/raising_the_roof.png', get_config_value(config, 'homepageContent.marketingImageUrl', 'assets/marketing_image.png'))
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/966/BANNER.png', get_config_value(config, 'homepageContent.warrantyBannerDesktopUrl', 'assets/warranty_banner_desktop.png'))
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/2936/banner-mobile.png', get_config_value(config, 'homepageContent.warrantyBannerMobileUrl', 'assets/warranty_banner_mobile.png'))
+    content = content.replace('https://cdn.treehouseinternetgroup.com/cms_images/801/no-nail-pledge-web.png', get_config_value(config, 'websiteSettings.noNailPledgeBadgeUrl', 'assets/no_nail_pledge.png'))
+
+    # External Font CSS
+    google_fonts_url = get_config_value(config, 'integrations.googleFontsUrl')
+    if google_fonts_url:
+        content = re.sub(r"https://fonts.googleapis.com/css\?family=Montserrat[^\"\'>]+", google_fonts_url, content)
+
+    adobe_kit_id = get_config_value(config, 'integrations.adobeFontsKitId')
+    if adobe_kit_id:
+        content = re.sub(r"https://use.typekit.net/[^\"\']+\.css", f"https://use.typekit.net/{adobe_kit_id}.css", content)
+
+    # Custom Core CSS/JS (replaced with actual links from config)
+    custom_css_url = get_config_value(config, 'websiteSettings.customCssUrl', 'assets/css/custom.css')
+    custom_js_url = get_config_value(config, 'websiteSettings.customJsUrl', 'assets/js/custom.js')
+    content = content.replace(PHP_PLACEHOLDERS["custom_core_v3_5_css"], f'<link rel="stylesheet" href="{custom_css_url}">')
+    content = content.replace(PHP_PLACEHOLDERS["custom_core_v3_js"], f'<script src="{custom_js_url}"></script>')
+
+    # CMS-Handled Placeholders (replace with HTML comments to note they are server-side)
+    for key in ["top_nav", "single_silo_nav", "social_footer", "breadcrumbs", "content_main", "city_scroll", "service_area_google_map"]:
+        content = content.replace(PHP_PLACEHOLDERS[key], f'<!-- {PHP_PLACEHOLDERS[key]} (Managed by CMS/PHP) -->')
+
+    # [[inline_css]] is a special case, should not be replaced by a config value here.
+    # It's meant for the PHP template system to inject CSS directly.
+
+    try:
+        with open(borders_file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        print(f"Processed and updated: {borders_file_path}")
+    except Exception as e:
+        print(f"Error writing changes to '{borders_file_path}': {e}")
+
+def process_css_file(file_path, config):
+    """Helper function to process a single CSS file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Error reading CSS file '{file_path}': {e}")
+        return
+
+    original_content = content
+    theme_config = get_config_value(config, "theme", {})
+
+    # Replace Colors
+    for old_color_pattern, config_key in CSS_COLOR_REPLACEMENTS:
+        new_color = theme_config.get(config_key)
+        if new_color:
+            try:
+                # Use word boundaries for hex colors to avoid partial replacements if a hex is part of a longer string
+                content = re.sub(r'\b' + old_color_pattern + r'\b', new_color, content, flags=re.IGNORECASE)
+            except re.error as e:
+                print(f"Regex error for color {old_color_pattern} with {new_color}: {e}")
+        # else:
+            # print(f"Warning: Color key '{config_key}' not found in theme config for CSS: {os.path.basename(file_path)}.")
+
+    # Replace Font Families
+    for old_font_pattern, config_key in CSS_FONT_REPLACEMENTS:
+        new_font = theme_config.get(config_key)
+        if new_font:
+            try:
+                content = re.sub(r"font-family:\s*" + old_font_pattern, rf"font-family: {new_font}", content, flags=re.IGNORECASE)
+            except re.error as e:
+                 print(f"Regex error for font {old_font_pattern} with {new_font}: {e}")
+        # else:
+            # print(f"Warning: Font key '{config_key}' not found in theme config for CSS: {os.path.basename(file_path)}.")
+
+    # Replace Specific URLs
+    css_filename = os.path.basename(file_path)
+    if css_filename in CSS_URL_REPLACEMENTS:
+        for old_url_pattern, config_key_path in CSS_URL_REPLACEMENTS[css_filename]:
+            new_url_value = get_config_value(config, config_key_path)
+            if new_url_value:
+                try:
+                    if "numberedListIconsPath" in config_key_path:
+                         # Replace path prefix, keep the icon number (e.g., /1.png, /2.png)
+                         content = re.sub(old_url_pattern, rf"url({new_url_value}\1.png)", content)
+                    else:
+                        content = re.sub(old_url_pattern, rf"url('{new_url_value}')", content)
+                except re.error as e:
+                    print(f"Regex error for URL {old_url_pattern} with {new_url_value}: {e}")
+            # else:
+                # print(f"Warning: URL key '{config_key_path}' not found in config for CSS: {css_filename}.")
+
+    if content != original_content:
+        try:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            print(f"Processed and updated CSS: {file_path}")
+        except Exception as e:
+            print(f"Error writing changes to CSS file '{file_path}': {e}")
+    # else:
+        # print(f"No changes made to CSS: {file_path}")
+
+def process_css_files(output_folder_path, config):
+    """Processes inline.css and template.css in the output folder."""
+    css_files_to_process = ['inline.css', 'template.css'] # Assuming these are at the root of output_folder_path
+    for css_file_name in css_files_to_process:
+        file_path = os.path.join(output_folder_path, css_file_name)
+        if os.path.exists(file_path):
+            process_css_file(file_path, config)
+        else:
+            print(f"Warning: CSS file '{file_path}' not found. Skipping.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a client-specific template from krs-main.")
+    parser.add_argument("config_path", help="Path to the client's config.json file.")
+    parser.add_argument("output_folder_name", help="Name for the new client template folder (e.g., krs-main-clientxyz).")
+
+    args = parser.parse_args()
+    script_dir = os.path.dirname(os.path.abspath(__file__)) # Absolute path to krs-main directory
+
+    # Create output folder relative to CWD
+    output_folder_path = create_output_folder(args.output_folder_name)
+    if not output_folder_path: return
+
+    # Copy files from script's directory (krs-main) to the new output folder
+    if not copy_template_files(script_dir, output_folder_path): return
+
+    config = load_config(args.config_path)
+    if not config: return
+
+    process_borders_php(output_folder_path, config)
+    process_css_files(output_folder_path, config)
+
+    print("\nClient template generation complete!")
+    print(f"Output located at: {output_folder_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a GitHub Action to automate the generation of client-specific templates from the krs-main base template.

Key additions and changes:

- **GitHub Action Workflow (`.github/workflows/generate-template.yml`):**
  - Manually triggered.
  - Takes client config filename and new branch name as inputs.
  - Checks out code, sets up Python.
  - Runs `generate_client_template.py` to create a customized template.
  - Commits the generated files to a new branch and pushes it to the repository.

- **Python Script (`krs-main/generate_client_template.py`):
  - Modified to output generated files to a directory relative to the repository root (e.g., `client_template_output/`), suitable for the GitHub Action.
  - Ensures the output directory is cleaned before generation.

- **README (`krs-main/README.md`):
  - Updated with a new section explaining how to use the GitHub Action, including trigger mechanism and input parameters.

- **Example Configuration (`krs-main/client_configs/example_client.json`):
  - Added an example client configuration file (a copy of the template) to demonstrate usage and facilitate testing of the GitHub Action.
  - The `krs-main/client_configs/` directory will store client-specific JSON configuration files.

This set of tools (Python script + config file + GitHub Action) streamlines the process of creating customized website templates for new clients, reducing manual effort and improving consistency.